### PR TITLE
Fixes for packaging

### DIFF
--- a/gildas-mode.el
+++ b/gildas-mode.el
@@ -1,9 +1,9 @@
-;;; gildas-mode.el --- Emacs mode for Gildas
+;;; gildas-mode.el --- Major mode for Gildas
 
 ;; Copyright (C) 2014-2015 Sébastien Maret
 
 ;; Author: Sébastien Maret <sebastien.maret@icloud.com>
-;; Package-Requires: ((polymode))
+;; Package-Requires: ((polymode "0") (emacs "24.3"))
 ;; Keywords: languages, gildas
 ;; URL: https://github.com/smaret/gildas-mode
 


### PR DESCRIPTION
- "Emacs" in the package description was redundant
- Package dependency without version was invalid
- `setq-local` requires Emacs 24.3

`flycheck-package` would have told you about the first 2 of these, had you been using it. :-)